### PR TITLE
[FEATURE] add ddev config

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,0 +1,222 @@
+name: dynamic-grid
+type: typo3
+docroot: .typo3/public
+php_version: "7.4"
+webserver_type: nginx-fpm
+router_http_port: "80"
+router_https_port: "443"
+xdebug_enabled: false
+additional_hostnames: []
+additional_fqdns: []
+database:
+  type: mariadb
+  version: "10.2"
+nfs_mount_enabled: false
+mutagen_enabled: false
+hooks:
+  post-start:
+  - composer: install
+  - exec: rm composer.lock
+  - exec: |
+      if [[ $(mysql -e "SHOW TABLES" | wc -l) -eq 0 ]]; then
+        rm .typo3/public/typo3conf/LocalConfiguration.php &> /dev/null || true
+        composer install-typo3
+      fi
+  # workaround for ddev v1.19 https://stackoverflow.com/questions/71509163/php-warning-in-typo3databasebackend-line-158-after-updating-ddev-to-1-19
+  - exec: sed -i 's/pdo_mysql/mysqli/' .typo3/public/typo3conf/AdditionalConfiguration.php 
+  - composer: typo3 cache:warmup
+  - composer: typo3cms database:updateschema
+  pre-start:
+  - exec-host: mkdir -p .typo3/public/typo3conf/ext/
+use_dns_when_possible: true
+composer_version: "2"
+web_environment:
+  - TYPO3_CONTEXT=Development/Local
+nodejs_version: "16"
+
+# Key features of ddev's config.yaml:
+
+# name: <projectname> # Name of the project, automatically provides
+#   http://projectname.ddev.site and https://projectname.ddev.site
+
+# type: <projecttype>  # drupal6/7/8, backdrop, typo3, wordpress, php
+
+# docroot: <relative_path> # Relative path to the directory containing index.php.
+
+# php_version: "7.4"  # PHP version to use, "5.6", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1"
+
+# You can explicitly specify the webimage but this
+# is not recommended, as the images are often closely tied to ddev's' behavior,
+# so this can break upgrades.
+
+# webimage: <docker_image>  # nginx/php docker image.
+
+# database:
+#   type: <dbtype> # mysql, mariadb
+#   version: <version> # database version, like "10.3" or "8.0"
+# Note that mariadb_version or mysql_version from v1.18 and earlier
+# will automatically be converted to this notation with just a "ddev config --auto"
+
+# router_http_port: <port>  # Port to be used for http (defaults to port 80)
+# router_https_port: <port> # Port for https (defaults to 443)
+
+# xdebug_enabled: false  # Set to true to enable xdebug and "ddev start" or "ddev restart"
+# Note that for most people the commands
+# "ddev xdebug" to enable xdebug and "ddev xdebug off" to disable it work better,
+# as leaving xdebug enabled all the time is a big performance hit.
+
+# xhprof_enabled: false  # Set to true to enable xhprof and "ddev start" or "ddev restart"
+# Note that for most people the commands
+# "ddev xhprof" to enable xhprof and "ddev xhprof off" to disable it work better,
+# as leaving xhprof enabled all the time is a big performance hit.
+
+# webserver_type: nginx-fpm  # or apache-fpm
+
+# timezone: Europe/Berlin
+# This is the timezone used in the containers and by PHP;
+# it can be set to any valid timezone,
+# see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+# For example Europe/Dublin or MST7MDT
+
+# composer_root: <relative_path>
+# Relative path to the composer root directory from the project root. This is
+# the directory which contains the composer.json and where all Composer related
+# commands are executed.
+
+# composer_version: "2"
+# if composer_version:"2" it will use the most recent composer v2
+# It can also be set to "1", to get most recent composer v1
+# or "" for the default v2 created at release time.
+# It can be set to any existing specific composer version.
+# After first project 'ddev start' this will not be updated until it changes
+
+# nodejs_version: "16"
+# change from the default system Node.js version to another supported version, like 12, 14, 17.
+# Note that you can use 'ddev nvm' or nvm inside the web container to provide nearly any
+# Node.js version, including v6, etc.
+
+# additional_hostnames:
+#  - somename
+#  - someothername
+# would provide http and https URLs for "somename.ddev.site"
+# and "someothername.ddev.site".
+
+# additional_fqdns:
+#  - example.com
+#  - sub1.example.com
+# would provide http and https URLs for "example.com" and "sub1.example.com"
+# Please take care with this because it can cause great confusion.
+
+# upload_dir: custom/upload/dir
+# would set the destination path for ddev import-files to <docroot>/custom/upload/dir
+
+# working_dir:
+#   web: /var/www/html
+#   db: /home
+# would set the default working directory for the web and db services.
+# These values specify the destination directory for ddev ssh and the
+# directory in which commands passed into ddev exec are run.
+
+# omit_containers: [db, dba, ddev-ssh-agent]
+# Currently only these containers are supported. Some containers can also be
+# omitted globally in the ~/.ddev/global_config.yaml. Note that if you omit
+# the "db" container, several standard features of ddev that access the
+# database container will be unusable. In the global configuration it is also
+# possible to omit ddev-router, but not here.
+
+# nfs_mount_enabled: false
+# Great performance improvement but requires host configuration first.
+# See https://ddev.readthedocs.io/en/stable/users/performance/#using-nfs-to-mount-the-project-into-the-container
+
+# mutagen_enabled: false
+# Experimental performance improvement using mutagen asynchronous updates.
+# See https://ddev.readthedocs.io/en/latest/users/performance/#using-mutagen
+
+# fail_on_hook_fail: False
+# Decide whether 'ddev start' should be interrupted by a failing hook
+
+# host_https_port: "59002"
+# The host port binding for https can be explicitly specified. It is
+# dynamic unless otherwise specified.
+# This is not used by most people, most people use the *router* instead
+# of the localhost port.
+
+# host_webserver_port: "59001"
+# The host port binding for the ddev-webserver can be explicitly specified. It is
+# dynamic unless otherwise specified.
+# This is not used by most people, most people use the *router* instead
+# of the localhost port.
+
+# host_db_port: "59002"
+# The host port binding for the ddev-dbserver can be explicitly specified. It is dynamic
+# unless explicitly specified.
+
+# phpmyadmin_port: "8036"
+# phpmyadmin_https_port: "8037"
+# The PHPMyAdmin ports can be changed from the default 8036 and 8037
+
+# host_phpmyadmin_port: "8036"
+# The phpmyadmin (dba) port is not normally bound on the host at all, instead being routed
+# through ddev-router, but it can be specified and bound.
+
+# mailhog_port: "8025"
+# mailhog_https_port: "8026"
+# The MailHog ports can be changed from the default 8025 and 8026
+
+# host_mailhog_port: "8025"
+# The mailhog port is not normally bound on the host at all, instead being routed
+# through ddev-router, but it can be bound directly to localhost if specified here.
+
+# webimage_extra_packages: [php7.4-tidy, php-bcmath]
+# Extra Debian packages that are needed in the webimage can be added here
+
+# dbimage_extra_packages: [telnet,netcat]
+# Extra Debian packages that are needed in the dbimage can be added here
+
+# use_dns_when_possible: true
+# If the host has internet access and the domain configured can
+# successfully be looked up, DNS will be used for hostname resolution
+# instead of editing /etc/hosts
+# Defaults to true
+
+# project_tld: ddev.site
+# The top-level domain used for project URLs
+# The default "ddev.site" allows DNS lookup via a wildcard
+# If you prefer you can change this to "ddev.local" to preserve
+# pre-v1.9 behavior.
+
+# ngrok_args: --subdomain mysite --auth username:pass
+# Provide extra flags to the "ngrok http" command, see
+# https://ngrok.com/docs#http or run "ngrok http -h"
+
+# disable_settings_management: false
+# If true, ddev will not create CMS-specific settings files like
+# Drupal's settings.php/settings.ddev.php or TYPO3's AdditionalConfiguration.php
+# In this case the user must provide all such settings.
+
+# You can inject environment variables into the web container with:
+# web_environment:
+# - SOMEENV=somevalue
+# - SOMEOTHERENV=someothervalue
+
+# no_project_mount: false
+# (Experimental) If true, ddev will not mount the project into the web container;
+# the user is responsible for mounting it manually or via a script.
+# This is to enable experimentation with alternate file mounting strategies.
+# For advanced users only!
+
+# bind_all_interfaces: false
+# If true, host ports will be bound on all network interfaces,
+# not just the localhost interface. This means that ports
+# will be available on the local network if the host firewall
+# allows it.
+
+# Many ddev commands can be extended to run tasks before or after the
+# ddev command is executed, for example "post-start", "post-import-db",
+# "pre-composer", "post-composer"
+# See https://ddev.readthedocs.io/en/stable/users/extending-commands/ for more
+# information on the commands that can be extended and the tasks you can define
+# for them. Example:
+#hooks:
+#  post-start:
+#    - exec: composer install -d /var/www/html

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /.build
 /node_modules
 /composer.lock
+
+# ddev installation
+/.typo3
+/vendor

--- a/README.md
+++ b/README.md
@@ -52,6 +52,25 @@
 ]
 ```
 
+## Local development environment
+
+There are several possibilities:
+
+### You can checkout this extension into your existing TYPO3 v11 and handle it as you would with a local package.
+
+The recommended way is to use a [composer `path` repository](https://getcomposer.org/doc/05-repositories.md#path).
+
+### You can use this extension as your root `composer` package and use the included DDEV configuration:
+
+```
+ddev start
+ddev launch /typo3
+```
+
+This installs a TYPO3 v11 into `./typo3`. The backend admin user is `admin`, password `adminadmin`.
+
+
+
 ## License
 
 GNU General Public License version 2 or later

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,3 @@
-
 {
   "name": "friendsoftypo3/dynamic-grid",
   "type": "typo3-cms-extension",
@@ -33,10 +32,67 @@
   },
   "extra": {
     "typo3/cms": {
-      "extension-key": "dynamic_grid"
+      "extension-key": "dynamic_grid",
+      "web-dir": ".typo3/public",
+      "app-dir": ".typo3"
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.5"
+    "phpunit/phpunit": "^8.5",
+    "typo3/cms-about": "^11.5",
+    "typo3/cms-adminpanel": "^11.5",
+    "typo3/cms-backend": "^11.5",
+    "typo3/cms-belog": "^11.5",
+    "typo3/cms-beuser": "^11.5",
+    "typo3/cms-dashboard": "^11.5",
+    "typo3/cms-extbase": "^11.5",
+    "typo3/cms-extensionmanager": "^11.5",
+    "typo3/cms-felogin": "^11.5",
+    "typo3/cms-filemetadata": "^11.5",
+    "typo3/cms-fluid": "^11.5",
+    "typo3/cms-fluid-styled-content": "^11.5",
+    "typo3/cms-form": "^11.5",
+    "typo3/cms-frontend": "^11.5",
+    "typo3/cms-impexp": "^11.5",
+    "typo3/cms-indexed-search": "^11.5",
+    "typo3/cms-info": "^11.5",
+    "typo3/cms-install": "^11.5",
+    "typo3/cms-linkvalidator": "^11.5",
+    "typo3/cms-lowlevel": "^11.5",
+    "typo3/cms-opendocs": "^11.5",
+    "typo3/cms-recordlist": "^11.5",
+    "typo3/cms-recycler": "^11.5",
+    "typo3/cms-redirects": "^11.5",
+    "typo3/cms-reports": "^11.5",
+    "typo3/cms-rte-ckeditor": "^11.5",
+    "typo3/cms-scheduler": "^11.5",
+    "typo3/cms-seo": "^11.5",
+    "typo3/cms-setup": "^11.5",
+    "typo3/cms-sys-note": "^11.5",
+    "typo3/cms-t3editor": "^11.5",
+    "typo3/cms-tstemplate": "^11.5",
+    "typo3/cms-viewpage": "^11.5",
+    "typo3/cms-workspaces": "^11.5",
+    "helhum/typo3-console": "^7.0"
+  },
+  "scripts": {
+    "post-autoload-dump": [
+      "[ -L .typo3/public/typo3conf/ext/dynamic_grid ] || ( mkdir -p .typo3/public/typo3conf/ext/ && ln -snvf ../../../../. .typo3/public/typo3conf/ext/dynamic_grid )"
+    ],
+    "install-typo3": [
+      "typo3cms install:setup --admin-user-name=admin --admin-password=adminadmin --site-setup-type=site --site-name='Dynamic Grid' --no-interaction"
+    ],
+    "typo3": [
+      "typo3"
+    ],
+    "typo3cms": [
+      "typo3cms"
+    ]
+  },
+  "config": {
+    "allow-plugins": {
+      "typo3/class-alias-loader": true,
+      "typo3/cms-composer-installers": true
+    }
   }
 }


### PR DESCRIPTION
This includes a little workaround for https://stackoverflow.com/questions/71509163/php-warning-in-typo3databasebackend-line-158-after-updating-ddev-to-1-19 by changing the MariaDB driver to `mysqli` from `pdo_mysql`.

https://github.com/drud/ddev/pull/3734