### PR TITLE
[FEATURE] add required page configuration and initial content

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -21,9 +21,10 @@ hooks:
       if [[ $(mysql -e "SHOW TABLES" | wc -l) -eq 0 ]]; then
         rm .typo3/public/typo3conf/LocalConfiguration.php &> /dev/null || true
         composer install-typo3
+        mysql < .ddev/template/dump.sql
       fi
   # workaround for ddev v1.19 https://stackoverflow.com/questions/71509163/php-warning-in-typo3databasebackend-line-158-after-updating-ddev-to-1-19
-  - exec: sed -i 's/pdo_mysql/mysqli/' .typo3/public/typo3conf/AdditionalConfiguration.php 
+  - exec: sed -i 's/pdo_mysql/mysqli/' .typo3/public/typo3conf/AdditionalConfiguration.php
   - composer: typo3 cache:warmup
   - composer: typo3cms database:updateschema
   pre-start:

--- a/.ddev/template/dump.sql
+++ b/.ddev/template/dump.sql
@@ -1,0 +1,38 @@
+UPDATE `pages`
+  SET TSconfig =
+				'mod.web_layout.BackendLayouts {\r\n  dynamic {\r\n    title = Example\r\n    config {\r\n      backend_layout {\r\n        colCount = 1\r\n        rowCount = 1\r\n        rows {\r\n          1 {\r\n            columns {\r\n              1 {\r\n                name = dynamic grid\r\n                colPos = 0\r\n                dynamicGrid = 1\r\n              }\r\n            }\r\n          }\r\n        }\r\n      }\r\n    }\r\n  }\r\n}',
+			backend_layout =
+				'pagets__dynamic',
+			tx_dynamicgrid_grid =
+				'[\r\n  {\r\n    \"colPos\":\"0\",\r\n    \"containers\": [\r\n      {\r\n        \"items\": [\r\n          {\r\n            \"size\": 1,\r\n            \"entities\": [\r\n              {\"name\":  \"tt_content\", \"identifier\": \"1\"}\r\n            ]\r\n          }\r\n        ]\r\n      },\r\n      {\r\n        \"items\": [\r\n          {\r\n            \"size\": 1,\r\n            \"entities\": [\r\n              {\"name\":  \"tt_content\", \"identifier\": \"2\"},\r\n              {\"name\":  \"tt_content\", \"identifier\": \"3\"}\r\n            ]\r\n          },\r\n          {\r\n            \"size\": 1,\r\n            \"entities\": [\r\n              {\"name\":  \"tt_content\", \"identifier\": \"4\"}\r\n            ]\r\n          }\r\n        ]\r\n      },\r\n      {\r\n        \"items\": [\r\n          {\r\n            \"size\": 1,\r\n            \"entities\": [\r\n              {\"name\":  \"tt_content\", \"identifier\": \"5\"}\r\n            ]\r\n          }\r\n        ]\r\n      }\r\n    ]\r\n  }\r\n]'
+	WHERE
+      uid = 1;
+
+
+INSERT INTO `tt_content`
+VALUES (1, '', 1, 1649341467, 1649341186, 1, 0, 0, 0, 0, '', 256, 0, 0, 0, 0, NULL, 0,
+				'{\"CType\":\"\",\"colPos\":\"\",\"header\":\"\",\"header_layout\":\"\",\"header_position\":\"\",\"date\":\"\",\"header_link\":\"\",\"subheader\":\"\",\"bodytext\":\"\",\"layout\":\"\",\"frame_class\":\"\",\"space_before_class\":\"\",\"space_after_class\":\"\",\"sectionIndex\":\"\",\"linkToTop\":\"\",\"sys_language_uid\":\"\",\"hidden\":\"\",\"starttime\":\"\",\"endtime\":\"\",\"fe_group\":\"\",\"editlock\":\"\",\"categories\":\"\",\"rowDescription\":\"\"}',
+				0, 0, 0, 0, 'text', 'Element 1', '',
+				'<p>First element, should be the first element on page, in dynamic grid 100%.</p>', 0, 0, 0, 0, 0, 0, 0, 2, 0,
+				0, 0, 'default', 0, '', '', NULL, NULL, 0, '', '', 0, '0', '', 1, 0, NULL, 0, '', '', '', 0, 0, 0, NULL, '', 0,
+				'', '', '', NULL, 124, 0, 0, 0, 0, NULL, 0),
+			 (2, '', 1, 1649342127, 1649341204, 1, 0, 0, 0, 0, '', 512, 0, 0, 0, 0, NULL, 0,
+				'{\"CType\":\"\",\"colPos\":\"\",\"header\":\"\",\"header_layout\":\"\",\"header_position\":\"\",\"date\":\"\",\"header_link\":\"\",\"subheader\":\"\",\"layout\":\"\",\"frame_class\":\"\",\"space_before_class\":\"\",\"space_after_class\":\"\",\"sectionIndex\":\"\",\"linkToTop\":\"\",\"sys_language_uid\":\"\",\"hidden\":\"\",\"starttime\":\"\",\"endtime\":\"\",\"fe_group\":\"\",\"editlock\":\"\",\"categories\":\"\",\"rowDescription\":\"\"}',
+				0, 0, 0, 0, 'header', '2th Element', '', NULL, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 'default', 0, '', '', NULL,
+				NULL, 0, '2nd row of 2 cols, 1st element left side', '', 0, '0', '', 1, 0, NULL, 0, '', '', '', 0, 0, 0, NULL,
+				'', 0, '', '', '', NULL, 124, 0, 0, 0, 0, NULL, 0),
+			 (3, '', 1, 1649342013, 1649341233, 1, 0, 0, 0, 0, '', 768, 0, 0, 0, 0, NULL, 0,
+				'{\"CType\":\"\",\"colPos\":\"\",\"header\":\"\",\"header_layout\":\"\",\"header_position\":\"\",\"date\":\"\",\"header_link\":\"\",\"subheader\":\"\",\"bodytext\":\"\",\"layout\":\"\",\"frame_class\":\"\",\"space_before_class\":\"\",\"space_after_class\":\"\",\"sectionIndex\":\"\",\"linkToTop\":\"\",\"sys_language_uid\":\"\",\"hidden\":\"\",\"starttime\":\"\",\"endtime\":\"\",\"fe_group\":\"\",\"editlock\":\"\",\"categories\":\"\",\"rowDescription\":\"\"}',
+				0, 0, 0, 0, 'text', 'Whats up?', '', '<p>Element 3, 3rd row, 1st element left side</p>', 0, 0, 0, 0, 0, 0, 0, 2,
+				0, 0, 0, 'default', 0, '', '', NULL, NULL, 0, 'WhatsApp', '', 0, '0', '', 1, 0, NULL, 0, '', '', '', 0, 0, 0,
+				NULL, '', 0, '', '', '', NULL, 124, 0, 0, 0, 0, NULL, 0),
+			 (4, '', 1, 1649341931, 1649341280, 1, 0, 0, 0, 0, '', 1024, 0, 0, 0, 0, NULL, 0,
+				'{\"CType\":\"\",\"colPos\":\"\",\"header\":\"\",\"header_layout\":\"\",\"header_position\":\"\",\"date\":\"\",\"header_link\":\"\",\"subheader\":\"\",\"bodytext\":\"\",\"layout\":\"\",\"frame_class\":\"\",\"space_before_class\":\"\",\"space_after_class\":\"\",\"sectionIndex\":\"\",\"linkToTop\":\"\",\"sys_language_uid\":\"\",\"hidden\":\"\",\"starttime\":\"\",\"endtime\":\"\",\"fe_group\":\"\",\"editlock\":\"\",\"categories\":\"\",\"rowDescription\":\"\"}',
+				0, 0, 0, 0, 'text', 'Get a new Element ', '', '<p>Second row, element 2 of 2, right side</p>', 0, 0, 0, 0, 0, 0,
+				0, 2, 0, 0, 0, 'default', 0, '', '', NULL, NULL, 0, '', '', 0, '0', '', 1, 0, NULL, 0, '', '', '', 0, 0, 0,
+				NULL, '', 0, '', '', '', NULL, 124, 0, 0, 0, 0, NULL, 0),
+			 (5, '', 1, 1649342050, 1649341310, 1, 0, 0, 0, 0, '', 1280, 0, 0, 0, 0, NULL, 0,
+				'{\"CType\":\"\",\"colPos\":\"\",\"header\":\"\",\"header_layout\":\"\",\"header_position\":\"\",\"date\":\"\",\"header_link\":\"\",\"subheader\":\"\",\"layout\":\"\",\"frame_class\":\"\",\"space_before_class\":\"\",\"space_after_class\":\"\",\"sectionIndex\":\"\",\"linkToTop\":\"\",\"sys_language_uid\":\"\",\"hidden\":\"\",\"starttime\":\"\",\"endtime\":\"\",\"fe_group\":\"\",\"editlock\":\"\",\"categories\":\"\",\"rowDescription\":\"\"}',
+				0, 0, 0, 0, 'header', '5th element of the world', '', NULL, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 'default', 0, '',
+				'', NULL, NULL, 0, 'We need final 5 elements here... 4th row, 1 element 100%', '', 0, '0', '', 1, 0, NULL, 0,
+				'', '', '', 0, 0, 0, NULL, '', 0, '', '', '', NULL, 124, 0, 0, 0, 0, NULL, 0);

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/.ddev export-ignore
+/.gitignore export-ignore
+/.nvmrc export-ignore
+/package.json export-ignore
+/tsconfig.json export-ignore
+/yarn.lock export-ignore


### PR DESCRIPTION
If the database is empty when ddev is started, after the automatic
typo3-console TYPO3 install:

 * A page layout containing a dynamic-grid-enabled column is added via
   inline TSConfig on the root page (uid=1)
 * That page layout is selected in backend_layout on the root page
 * 5 content elements are added to the page and the grid via
   `pages`.`tx_dynamicgrid_grid` on the root page
